### PR TITLE
Remove the explicit href prop.

### DIFF
--- a/src/components/link-preview.svelte
+++ b/src/components/link-preview.svelte
@@ -1,8 +1,6 @@
 <script>
   import LinkPreviewCard from "./link-preview-card.svelte";
 
-  export let href;
-
   let showPreviewCard = false;
 </script>
 
@@ -12,7 +10,7 @@
   }
 </style>
 
-<a {href} {...$$restProps} on:mouseover={() => showPreviewCard = true} on:mouseleave={() => showPreviewCard = false}>
+<a href={$$props.href} {...$$props} on:mouseover={() => showPreviewCard = true} on:mouseleave={() => showPreviewCard = false}>
   <slot />
-  <LinkPreviewCard {href} show={showPreviewCard} />
+  <LinkPreviewCard href={$$props.href} show={showPreviewCard} />
 </a>


### PR DESCRIPTION
There's no need to explicitly expose the `href` prop from the `<LinkPreview>` component as we can use `$$props` to access it and set explicitly on the `<a>` tag to make sure it passes accessibility standards.